### PR TITLE
Fix cache control value separator

### DIFF
--- a/packages/stash_dio/lib/src/dio/header_value.dart
+++ b/packages/stash_dio/lib/src/dio/header_value.dart
@@ -222,6 +222,20 @@ abstract class HeaderValue {
     return _HeaderValue(value, parameters);
   }
 
+  /// Creates a new cache-control header value object from parsing a header
+  /// value string with both value and optional parameters.
+  ///
+  /// * [value]: The cache-control header directive
+  ///
+  /// Returns a [HeaderValue]
+  static HeaderValue parseCacheControl(String value) {
+    return HeaderValue.parse(
+      'cache-control: $value',
+      parameterSeparator: ',',
+      valueSeparator: '=',
+    );
+  }
+
   /// Creates a new header value object from parsing a header value
   /// string with both value and optional parameters.
   ///

--- a/packages/stash_dio/lib/src/dio/interceptor_builder.dart
+++ b/packages/stash_dio/lib/src/dio/interceptor_builder.dart
@@ -165,9 +165,7 @@ class CacheInterceptorBuilder {
     var cacheControl = response.headers.value('cache-control');
     if (cacheControl != null) {
       // try to get maxAge and maxStale from cacheControl
-      var parameters = HeaderValue.parse('cache-control: $cacheControl',
-              parameterSeparator: '', valueSeparator: '=')
-          .parameters;
+      var parameters = HeaderValue.parseCacheControl(cacheControl).parameters;
       maxAge = _tryGetDurationFromMap(parameters, 's-maxage');
       maxAge ??= _tryGetDurationFromMap(parameters, 'max-age');
       // if staleTime has value, don't get max-stale anymore.

--- a/packages/stash_dio/test/dio/header_value_test.dart
+++ b/packages/stash_dio/test/dio/header_value_test.dart
@@ -1,0 +1,17 @@
+import 'package:stash_dio/src/dio/header_value.dart';
+import 'package:test/test.dart';
+
+void main() async {
+  test('Header value parsing', () {
+    expect(
+        HeaderValue.parseCacheControl(
+                'no-cache, no-store, max-age=0, must-revalidate')
+            .parameters,
+        {
+          'no-cache': null,
+          'no-store': null,
+          'max-age': '0',
+          'must-revalidate': null
+        });
+  });
+}


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
stash_dio does not seem to be able to handle commas in the cache-control header

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Examples
