### PR TITLE
feat(stash_sqlite): use NativeDatabase.createInBackground factory

### DIFF
--- a/packages/stash_sqlite/lib/src/sqlite/sqlite_adapter.dart
+++ b/packages/stash_sqlite/lib/src/sqlite/sqlite_adapter.dart
@@ -93,7 +93,7 @@ class SqliteFileAdapter<I extends Info, E extends Entry<I>>
       SqliteBuilder<I, E> builder, File file,
       {bool? logStatements, DatabaseSetup? setup}) {
     return Future.value(SqliteFileAdapter._(
-        builder(NativeDatabase(file,
+        builder(NativeDatabase.createInBackground(file,
             logStatements: logStatements ?? false, setup: setup)),
         file));
   }


### PR DESCRIPTION
## Status
**READY**

## Breaking Changes
NO

## Description
Use NativeDatabase.createInBackground factory to spawn a long-running isolate to run SQL statements and avoid accessing the database from the main isolate (which can cause blocking IO operations).
Fixes #67 
